### PR TITLE
[Bug Report] Update clothing_mods.json

### DIFF
--- a/Really_Dark_Skies/items/clothing_mods.json
+++ b/Really_Dark_Skies/items/clothing_mods.json
@@ -3,7 +3,7 @@
     "type": "clothing_mod",
     "id": "dkz_xeno-plated",
     "flag": "dkz_xeno-plated",
-    "item": "dkz_blend_mat",
+    "item": "dkz_blend_scrap",
     "implement_prompt": "Add the Prismetallic metal",
     "destroy_prompt": "Remove the Prismetallic metal",
     "mod_value": [
@@ -17,7 +17,7 @@
     "type": "clothing_mod",
     "id": "dkz_xeno-weave",
     "flag": "dkz_xeno-weave",
-    "item": "dkz_weave_mat",
+    "item": "dkz_weave_scrap",
     "implement_prompt": "Weave with chromogenic material",
     "destroy_prompt": "Destroy the chromogenic material",
     "mod_value": [


### PR DESCRIPTION
ERROR/ISSUE DISCOVERED: Armor mods flag with an invalid material message. 

17:13:53.988 ERROR DEBUGMSG : D:\a\Cataclysm-BN\Cataclysm-BN\src\item_factory.cpp:1610 [find_template] Missing item definition: dkz_blend_mat
17:13:56.644 ERROR DEBUGMSG : D:\a\Cataclysm-BN\Cataclysm-BN\src\item_factory.cpp:1610 [find_template] Missing item definition: dkz_weave_mat

FIX: The armor mods had their associated "Item" entry showing the material. They just need changed to reflect the item used for the clothing mod - in this case, the xenoid metal and cloth scraps.

ALTERNATE SOLUTIONS: Live in a world where these clothing mods remain forever broken and sad.

NOTES: Looks like these haven't been implemented yet into any of the tool lists that would allow a clothing mod, so this isn't a high priority fix by any means.

